### PR TITLE
Add multiple daily ratelimits support

### DIFF
--- a/server/src/core/abstracts/ratelimiter/rate-limiter.types.ts
+++ b/server/src/core/abstracts/ratelimiter/rate-limiter.types.ts
@@ -6,9 +6,14 @@ export type RateLimitOptions = {
     limit?: string;
     reset?: string;
   };
-  dailyRateLimit?: number;
+  dailyRateLimits?: DailyRateLimit[];
   rateLimits: RateLimit[];
   onCooldownUntil?: number; // Active only if we got 429 status code before
+};
+
+export type DailyRateLimit = {
+  limit: number;
+  abilities?: ClientAbilities[]; // If undefined, applies to all abilities
 };
 
 export type RateLimit = {

--- a/server/src/core/domains/beatmaps.download/osulabs.client.ts
+++ b/server/src/core/domains/beatmaps.download/osulabs.client.ts
@@ -28,7 +28,7 @@ export class OsulabsClient extends BaseClient {
         ],
       },
       {
-        dailyRateLimit: 10000,
+        dailyRateLimits: [{ limit: 10000 }],
         headers: {
           remaining: "x-ratelimit-remaining",
         },

--- a/server/src/core/domains/catboy.best/mino.client.ts
+++ b/server/src/core/domains/catboy.best/mino.client.ts
@@ -33,7 +33,18 @@ export class MinoClient extends BaseClient {
         ],
       },
       {
-        dailyRateLimit: 10000,
+        dailyRateLimits: [
+          { limit: 10000 },
+          {
+            limit: 2000,
+            // Mino has nested daily rate limits for downloads
+            abilities: [
+              ClientAbilities.DownloadBeatmapSetById,
+              ClientAbilities.DownloadBeatmapSetByIdNoVideo,
+              ClientAbilities.DownloadOsuBeatmap,
+            ],
+          },
+        ],
         headers: {
           remaining: "x-ratelimit-remaining",
         },


### PR DESCRIPTION
This PR adds multiple daily ratelimit support for specific abilities.

This is mainly focused for mino mirror, which has downloads daily ratelimits support. 



![](https://media.tenor.com/cKyS85PujZUAAAAi/arknights-enfield.gif)