### PR TITLE
Add support for USE_US_CATBOY_SERVER_ONLY

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,5 @@ DISABLE_SAFE_RATELIMIT_MODE= # Optional: By default, we use only 90% of the avai
 DISABLE_DAILY_RATE_LIMIT= # Optional: Add 'true' to ignore all daily ratelimits. 
 ENABLE_CRON_TO_CLEAR_OUTDATED_BEATMAPS= # Optional: Enable this if you are having problems with a disk space due to the database. Add 'true' to enable. 
 SHOW_INTERNAL_VALUES_IN_PUBLIC_STATS_ENDPOINT= # Optional: By default, internal values (like each mirror's usage ratelimits, env values, etc.) are hidden in the /stats endpoint. Add 'true' to enable. 
+
+USE_US_CATBOY_SERVER_ONLY= # Optional: Add 'true' to use US catboy server as the only source of beatmap data. Use this if you have problems with catboy.best (mino) mirror.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
             - uses: actions/checkout@v4
             - uses: oven-sh/setup-bun@v2
 
-            - run: docker compose -f docker-compose.tests.yml up --detach
+            - run: docker compose -f docker-compose.tests.yml up --detach --wait
             - run: bun install --frozen-lockfile
             - run: bun lint
             - run: bun test

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./server/tests/setup.ts"]

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -35,6 +35,7 @@ const {
   DISABLE_DAILY_RATE_LIMIT,
   ENABLE_CRON_TO_CLEAR_OUTDATED_BEATMAPS,
   SHOW_INTERNAL_VALUES_IN_PUBLIC_STATS_ENDPOINT,
+  USE_US_CATBOY_SERVER_ONLY, // TODO: Hopefully a temporary solution for catboy.best (mino) mirror problems. Consider removing this in the future when the mirror is more stable.
 } = process.env;
 
 if (!POSTGRES_USER || !POSTGRES_PASSWORD) {
@@ -77,6 +78,7 @@ const config: {
   DisableDailyRateLimit: boolean;
   EnableCronToClearOutdatedBeatmaps: boolean;
   ShowInternalValuesInPublicStatsEndpoint: boolean;
+  UseUsCatboyServerOnly: boolean;
 } = {
   PORT: PORT || "3000",
   POSTGRES_USER: POSTGRES_USER || "admin",
@@ -104,6 +106,7 @@ const config: {
         ENABLE_CRON_TO_CLEAR_OUTDATED_BEATMAPS === "true",
   ShowInternalValuesInPublicStatsEndpoint:
         SHOW_INTERNAL_VALUES_IN_PUBLIC_STATS_ENDPOINT === "true",
+  UseUsCatboyServerOnly: USE_US_CATBOY_SERVER_ONLY === "true",
 };
 
 export const observatoryConfigPublic = {
@@ -119,6 +122,7 @@ export const observatoryConfigPublic = {
   DisableDailyRateLimit: DISABLE_DAILY_RATE_LIMIT === "true",
   EnableCronToClearOutdatedBeatmaps:
         ENABLE_CRON_TO_CLEAR_OUTDATED_BEATMAPS === "true",
+  UseUsCatboyServerOnly: USE_US_CATBOY_SERVER_ONLY === "true",
 };
 
 export default config;

--- a/server/src/core/domains/catboy.best/mino.client.ts
+++ b/server/src/core/domains/catboy.best/mino.client.ts
@@ -1,5 +1,6 @@
 import qs from "qs";
 
+import config from "../../../config";
 import type { Beatmap, Beatmapset } from "../../../types/general/beatmap";
 import logger from "../../../utils/logger";
 import { BaseClient } from "../../abstracts/client/base-client.abstract";
@@ -21,7 +22,7 @@ export class MinoClient extends BaseClient {
   constructor(storageManager: StorageManager) {
     super(
       {
-        baseUrl: "https://catboy.best",
+        baseUrl: config.UseUsCatboyServerOnly ? "https://us.catboy.best" : "https://catboy.best",
         abilities: [
           ClientAbilities.GetBeatmapById,
           ClientAbilities.GetBeatmapSetById,

--- a/server/src/core/services/convert.service.ts
+++ b/server/src/core/services/convert.service.ts
@@ -27,6 +27,7 @@ export class ConvertService {
       case "https://osu.ppy.sh":
         this.mirror = "bancho";
         break;
+      case "https://us.catboy.best":
       case "https://catboy.best":
         this.mirror = "mino";
         break;
@@ -110,8 +111,8 @@ export class ConvertService {
     return {
       ...beatmap,
       failtimes: {
-        fail: Array.from({ length: 100 }).fill(0),
-        exit: Array.from({ length: 100 }).fill(0),
+        fail: Array.from<number>({ length: 100 }).fill(0),
+        exit: Array.from<number>({ length: 100 }).fill(0),
       },
     };
   }

--- a/server/tests/mirrors.manager.test.ts
+++ b/server/tests/mirrors.manager.test.ts
@@ -45,8 +45,6 @@ describe("MirrorsManager", () => {
   let mockStorageManager: StorageManager;
 
   beforeAll(async () => {
-    await Mocker.ensureDatabaseInitialized();
-
     mockStorageManager = {
       getBeatmapSet: mock(async () => {}),
       insertBeatmapset: mock(async () => {}),

--- a/server/tests/setup.ts
+++ b/server/tests/setup.ts
@@ -1,0 +1,20 @@
+import path from "node:path";
+
+import { migrate } from "drizzle-orm/node-postgres/migrator";
+
+import { db } from "../src/database/client";
+import { RedisInstance } from "../src/plugins/redisInstance";
+
+const migrationPath = path.join(
+  process.cwd(),
+  "server/src/database/migrations",
+);
+
+try {
+  await migrate(db, { migrationsFolder: migrationPath });
+}
+catch {
+  throw new Error("Failed to migrate the database for testing");
+}
+
+await RedisInstance.flushdb();

--- a/server/tests/stats.endpoint.test.ts
+++ b/server/tests/stats.endpoint.test.ts
@@ -1,7 +1,6 @@
 import { HttpStatusCode } from "axios";
 import {
   afterEach,
-  beforeAll,
   beforeEach,
   describe,
   expect,
@@ -17,10 +16,6 @@ import { Mocker } from "./utils/mocker";
 describe("Stats Endpoint", () => {
   let app: Elysia;
   const originalEnv = config.ShowInternalValuesInPublicStatsEndpoint;
-
-  beforeAll(async () => {
-    await Mocker.ensureDatabaseInitialized();
-  });
 
   beforeEach(async () => {
     jest.restoreAllMocks();


### PR DESCRIPTION
We are adding new env value of `USE_US_CATBOY_SERVER_ONLY`, which will fallback to the `us` mino server, instead of relying on the server we could be provided by the mino itself (since it may be faulty, and from my experience `us` was stablest).